### PR TITLE
Aggiorna inviti telegram non funzionanti nelle pagine.

### DIFF
--- a/en/extra/sport/index.html
+++ b/en/extra/sport/index.html
@@ -81,7 +81,7 @@
             <p class="card-text">Have you ever wondered if someone wanted to come to a sporting event with you? Do you need a fifth player for five-a-side football? Are you looking for somebody to go running with? The group is born to satisfy these needs. Good training 💪</p>
           </div>
           <div class="card-footer">
-            <a href="https://t.me/joinchat/LclXl04V6mhZXFXKDwLgIQ" class="btn btn-primary btn-sm">Open link</a>
+            <a href="https://t.me/joinchat/ThXqaFlKDWI__KHo" class="btn btn-primary btn-sm">Open link</a>
           </div>
         </div>
       </div>

--- a/it/extra/index.html
+++ b/it/extra/index.html
@@ -161,10 +161,10 @@
 				</div>
 				<div class="col-lg-4 col-sm-6 portfolio-item">
 					<div class="card h-100">
-						<a href="https://t.me/joinchat/LclXl1EnkkfS8j4C1YxSmQ"><img class="card-img-top" src="../../img/11.jpg" alt="" /></a>
+						<a href="https://t.me/joinchat/USeSRyfefoBFU4CZ"><img class="card-img-top" src="../../img/11.jpg" alt="" /></a>
 						<div class="card-body">
 							<h4 class="card-title">
-								<a href="https://t.me/joinchat/LclXl1EnkkfS8j4C1YxSmQ"><img src="../../img/tg.svg" style="width: 18px;" /> InfoSec World</a>
+								<a href="https://t.me/joinchat/USeSRyfefoBFU4CZ"><img src="../../img/tg.svg" style="width: 18px;" /> InfoSec World</a>
 							</h4>
 							<p class="card-text">Sicurezza informatica e tante altre cose complicate</p>
 						</div>

--- a/it/extra/sport/index.html
+++ b/it/extra/sport/index.html
@@ -81,7 +81,7 @@
             <p class="card-text">Vi siete mai chiesti se qualcuno vuol venire ad un evento sportivo con voi? O vi serve un quinto giocatore per calcetto? O cercate una compagnia per andare a correre? Il gruppo nasce per soddisfare questi bisogni. Good training 💪</p>
           </div>
           <div class="card-footer">
-            <a href="https://t.me/joinchat/LclXl04V6mhZXFXKDwLgIQ" class="btn btn-primary btn-sm">Apri link</a>
+            <a href="https://t.me/joinchat/ThXqaFlKDWI__KHo" class="btn btn-primary btn-sm">Apri link</a>
           </div>
         </div>
       </div>

--- a/it/guides/info/corsi2.txt
+++ b/it/guides/info/corsi2.txt
@@ -50,7 +50,7 @@ La prof Barbera e' molto tranquilla, pur essendo stato l'anno scorso il suo prim
 L'esame e' facile, tipicamente la meta' delle domande  facili, alcune domande di media difficolta, e poche domande molto impegnative.
 
 ###Misure
-TELEGRAM https://t.me/joinchat/LclXl0IS_pOXttKaM5h6Lw
+TELEGRAM https://t.me/joinchat/QhL-k0uUwZIxVoQf
 MANIFEST https://www11.ceda.polimi.it/schedaincarico/schedaincarico/controller/scheda_pubblica/SchedaPublic.do?&evn_default=evento&c_classe=743827&polij_device_category=DESKTOP&__pj0=0&__pj1=aa02ffbdbc2d57f38b6d1994f9607964
 Nota: Docente cambiato
 
@@ -78,7 +78,7 @@ bianco o comunque fai ridere, ti boccia e ti fa fare il salto d'appello.
 Scelto principalmente come corso leggero alternativo a chimica. Tratta principalmente di teoria della misura e di strumenti di misurazione, quindi introduce alla statistica e all'elettronica. Gli argomenti sono belli se vi interessate un minimo di elettronica e volete saperne di più su voltmetri e multimetri, ma la parte sulla misurazione può risultare noiosa. Una cosa positiva del corso è che introduce argomenti che poi si ritrovano in probabilità e statistica, fondamenti di automatica ed elettronica (distribuzioni, campionamenti, DAC, ADC). Nota positivissima sono gli esami: sono praticamente tutti uguali e ci sono tante tracce degli anni passati disponibili.
 
 ###Onde elettromagnetiche e mezzi trasmissivi
-TELEGRAM https://t.me/joinchat/CubjAAuj8xdGVyPqgJftLg
+TELEGRAM https://t.me/joinchat/LclXl1D5zASzZXWEBzYEBA
 MANIFEST https://www11.ceda.polimi.it/schedaincarico/schedaincarico/controller/scheda_pubblica/SchedaPublic.do?&evn_default=evento&c_classe=743818&polij_device_category=DESKTOP&__pj0=0&__pj1=c4165f7c668d0063a0915f3724e44cbf
 Corso a mio parere interessante. Personalmente odio la parte di
 elettromagnetismo, ma in questo corso è ridotta davvero all’osso e

--- a/it/guides/info/corsi3.txt
+++ b/it/guides/info/corsi3.txt
@@ -4,7 +4,7 @@ Questa guida è stata redatta dagli admin di Ingegneria Informatica del Polinetw
 Cliccate sul nome del corso per aprirne la pagina e leggere il programma dettagliato.
 
 ###BIOINFORMATICS ALGORITHMS
-TELEGRAM https://t.me/joinchat/LclXl0mB9m3teTuVX4MGDw
+TELEGRAM https://t.me/joinchat/SYH2bcCemecUZiZA
 MANIFEST https://www11.ceda.polimi.it/schedaincarico/schedaincarico/controller/scheda_pubblica/SchedaPublic.do?&evn_default=evento&c_classe=744529&polij_device_category=DESKTOP&__pj0=0&__pj1=9e3441292d61f42e8f252763f3c37183
 A primo impatto il nome potrebbe trarre in inganno, infatti molti credono che questo corso
 tratti prevalentemente argomenti di biologia e che quindi siano richieste conoscenze
@@ -134,7 +134,7 @@ utilizzate sono abbastanza datate offre un'ottima base per capire quelle più mo
 Fraternali è un ottimo professore.
 
 ###SOFTWARE DEFINED NETWORKING
-TELEGRAM https://t.me/joinchat/LclXl0IWxGg3yqZGYfDByw
+TELEGRAM https://t.me/joinchat/QhbEaLmNUETzNdfr
 MANIFEST https://www11.ceda.polimi.it/schedaincarico/schedaincarico/controller/scheda_pubblica/SchedaPublic.do?&evn_default=evento&c_classe=691339&polij_device_category=DESKTOP&__pj0=0&__pj1=b32d9a733d99f06fae7d08905ec155d5
 Indubbiamente è un corso pensato maggiormente per i telecom, ma super fattibile per
 chiunque abbia rudimenti di internet e reti (esame che tutti noi abbiamo fatto al primo
@@ -155,7 +155,7 @@ esercizi (a meno di qualche variazione) sono sempre gli stessi e una volta capit
 meccanismo si fanno con tranquillità. Quindi lo consiglio.
 
 ###AUTOMAZIONE INDUSTRIALE
-TELEGRAM https://t.me/joinchat/LclXl0YtuPA8tMCIgVAQyA
+TELEGRAM https://t.me/joinchat/Ri248OkMNyWNsYSW
 MANIFEST https://www11.ceda.polimi.it/schedaincarico/schedaincarico/controller/scheda_pubblica/SchedaPublic.do?&evn_default=evento&c_classe=617878&polij_device_category=DESKTOP&__pj0=0&__pj1=586e63f78dd1f0ce7a02946955f35892
 La materia è abbastanza interessante, in particolare la seconda parte del corso. La prima è
 molto meccanica e può invece risultare noiosa. Il professore è chiaro e l’esercitatore molto
@@ -193,7 +193,7 @@ esame troppo complesso per i cfu che offre ma senza perdere lo stimolo allo stud
 dal poco interesse.
 
 ###KNOWLEDGE ENGINEERING
-TELEGRAM https://t.me/joinchat/LclXl1J4D7z2UClaire9TQ
+TELEGRAM https://t.me/joinchat/UngPvH-7huj-jin4
 MANIFEST https://www11.ceda.polimi.it/schedaincarico/schedaincarico/controller/scheda_pubblica/SchedaPublic.do?&evn_default=evento&c_classe=667271&polij_device_category=DESKTOP&__pj0=0&__pj1=1467dab57c0890853f6b321e760cd297
 Il corso è interessante, l'esame non è difficilissimo, purtroppo zero coordinazione tra i due
 insegnanti che gestiscono le due metà del corso, e mentre il professore principale era
@@ -215,7 +215,7 @@ techniques. I say this because the preparation and experience of Prof. Colombett
 amazing and it's definitely something worth experiencing.
 
 ###ROBOTICS
-TELEGRAM https://t.me/joinchat/LclXl1NcelHbCuLT10v8oQ
+TELEGRAM https://t.me/joinchat/U1x6USuzBdbdGgUW
 MANIFEST https://www11.ceda.polimi.it/schedaincarico/schedaincarico/controller/scheda_pubblica/SchedaPublic.do?&evn_default=evento&c_classe=667653&polij_device_category=DESKTOP&__pj0=0&__pj1=a1b3fb0de8d506ddc89e80beb9d5228d
 Corso molto interessante, forse più di quanto appare dalla sua presentazione sul piano
 studi. Ho avuto l'impressione che tanta gente lo scarti a priori pensando che si tratti di un
@@ -277,7 +277,7 @@ La mia opinione è complessivamente positiva, sia per quanto riguarda gli argome
 modo in cui sono stati spiegati, che il taglio generale del corso.
 
 ###SICUREZZA DELLE RETI
-TELEGRAM https://t.me/joinchat/LclXl1jeOj5MgaS0SMtsmQ
+TELEGRAM https://t.me/joinchat/WN46PhUFZ4CxSiB2
 MANIFEST https://www11.ceda.polimi.it/schedaincarico/schedaincarico/controller/scheda_pubblica/SchedaPublic.do?&evn_default=evento&c_classe=712674&polij_device_category=DESKTOP&__pj0=0&__pj1=d3ed0e0e341de91a0c53fbe462fca676
 Il nome del corso è magari leggermente fuorviante, il contenuto è teoria dei numeri e
 protocolli di comunicazione sicura. Il professore è simpatico e spiega bene, il corso

--- a/it/guides/testanddev/corsi2.txt
+++ b/it/guides/testanddev/corsi2.txt
@@ -48,7 +48,7 @@ La prof Barbera e' molto tranquilla, pur essendo stato l'anno scorso il suo prim
 L'esame e' facile, tipicamente la meta' delle domande  facili, alcune domande di media difficolta, e poche domande molto impegnative.
 
 ###Misure
-TELEGRAM https://t.me/joinchat/LclXl0IS_pOXttKaM5h6Lw
+TELEGRAM https://t.me/joinchat/QhL-k0uUwZIxVoQf
 MANIFEST https://www11.ceda.polimi.it/schedaincarico/schedaincarico/controller/scheda_pubblica/SchedaPublic.do?&evn_default=evento&c_classe=743827&polij_device_category=DESKTOP&__pj0=0&__pj1=aa02ffbdbc2d57f38b6d1994f9607964
 Nota: Docente cambiato
 
@@ -76,7 +76,7 @@ bianco o comunque fai ridere, ti boccia e ti fa fare il salto d'appello.
 Scelto principalmente come corso leggero alternativo a chimica. Tratta principalmente di teoria della misura e di strumenti di misurazione, quindi introduce alla statistica e all'elettronica. Gli argomenti sono belli se vi interessate un minimo di elettronica e volete saperne di più su voltmetri e multimetri, ma la parte sulla misurazione può risultare noiosa. Una cosa positiva del corso è che introduce argomenti che poi si ritrovano in probabilità e statistica, fondamenti di automatica ed elettronica (distribuzioni, campionamenti, DAC, ADC). Nota positivissima sono gli esami: sono praticamente tutti uguali e ci sono tante tracce degli anni passati disponibili.
 
 ###Onde elettromagnetiche e mezzi trasmissivi
-TELEGRAM https://t.me/joinchat/CubjAAuj8xdGVyPqgJftLg
+TELEGRAM https://t.me/joinchat/LclXl1D5zASzZXWEBzYEBA
 MANIFEST https://www11.ceda.polimi.it/schedaincarico/schedaincarico/controller/scheda_pubblica/SchedaPublic.do?&evn_default=evento&c_classe=743818&polij_device_category=DESKTOP&__pj0=0&__pj1=c4165f7c668d0063a0915f3724e44cbf
 Corso a mio parere interessante. Personalmente odio la parte di
 elettromagnetismo, ma in questo corso è ridotta davvero all’osso e

--- a/it/guides/testanddev/corsi3.txt
+++ b/it/guides/testanddev/corsi3.txt
@@ -4,7 +4,7 @@ Questa guida è stata redatta dagli admin di Ingegneria Informatica del Polinetw
 Cliccate sul nome del corso per aprirne la pagina e leggere il programma dettagliato.
 
 ###BIOINFORMATICS ALGORITHMS
-TELEGRAM https://t.me/joinchat/LclXl0mB9m3teTuVX4MGDw
+TELEGRAM https://t.me/joinchat/SYH2bcCemecUZiZA
 MANIFEST https://www11.ceda.polimi.it/schedaincarico/schedaincarico/controller/scheda_pubblica/SchedaPublic.do?&evn_default=evento&c_classe=744529&polij_device_category=DESKTOP&__pj0=0&__pj1=9e3441292d61f42e8f252763f3c37183
 A primo impatto il nome potrebbe trarre in inganno, infatti molti credono che questo corso
 tratti prevalentemente argomenti di biologia e che quindi siano richieste conoscenze
@@ -134,7 +134,7 @@ utilizzate sono abbastanza datate offre un'ottima base per capire quelle più mo
 Fraternali è un ottimo professore.
 
 ###SOFTWARE DEFINED NETWORKING
-TELEGRAM https://t.me/joinchat/LclXl0IWxGg3yqZGYfDByw
+TELEGRAM https://t.me/joinchat/QhbEaLmNUETzNdfr
 MANIFEST https://www11.ceda.polimi.it/schedaincarico/schedaincarico/controller/scheda_pubblica/SchedaPublic.do?&evn_default=evento&c_classe=691339&polij_device_category=DESKTOP&__pj0=0&__pj1=b32d9a733d99f06fae7d08905ec155d5
 Indubbiamente è un corso pensato maggiormente per i telecom, ma super fattibile per
 chiunque abbia rudimenti di internet e reti (esame che tutti noi abbiamo fatto al primo
@@ -155,7 +155,7 @@ esercizi (a meno di qualche variazione) sono sempre gli stessi e una volta capit
 meccanismo si fanno con tranquillità. Quindi lo consiglio.
 
 ###AUTOMAZIONE INDUSTRIALE
-TELEGRAM https://t.me/joinchat/LclXl0YtuPA8tMCIgVAQyA
+TELEGRAM https://t.me/joinchat/Ri248OkMNyWNsYSW
 MANIFEST https://www11.ceda.polimi.it/schedaincarico/schedaincarico/controller/scheda_pubblica/SchedaPublic.do?&evn_default=evento&c_classe=617878&polij_device_category=DESKTOP&__pj0=0&__pj1=586e63f78dd1f0ce7a02946955f35892
 La materia è abbastanza interessante, in particolare la seconda parte del corso. La prima è
 molto meccanica e può invece risultare noiosa. Il professore è chiaro e l’esercitatore molto
@@ -193,7 +193,7 @@ esame troppo complesso per i cfu che offre ma senza perdere lo stimolo allo stud
 dal poco interesse.
 
 ###KNOWLEDGE ENGINEERING
-TELEGRAM https://t.me/joinchat/LclXl1J4D7z2UClaire9TQ
+TELEGRAM https://t.me/joinchat/UngPvH-7huj-jin4
 MANIFEST https://www11.ceda.polimi.it/schedaincarico/schedaincarico/controller/scheda_pubblica/SchedaPublic.do?&evn_default=evento&c_classe=667271&polij_device_category=DESKTOP&__pj0=0&__pj1=1467dab57c0890853f6b321e760cd297
 Il corso è interessante, l'esame non è difficilissimo, purtroppo zero coordinazione tra i due
 insegnanti che gestiscono le due metà del corso, e mentre il professore principale era
@@ -215,7 +215,7 @@ techniques. I say this because the preparation and experience of Prof. Colombett
 amazing and it's definitely something worth experiencing.
 
 ###ROBOTICS
-TELEGRAM https://t.me/joinchat/LclXl1NcelHbCuLT10v8oQ
+TELEGRAM https://t.me/joinchat/U1x6USuzBdbdGgUW
 MANIFEST https://www11.ceda.polimi.it/schedaincarico/schedaincarico/controller/scheda_pubblica/SchedaPublic.do?&evn_default=evento&c_classe=667653&polij_device_category=DESKTOP&__pj0=0&__pj1=a1b3fb0de8d506ddc89e80beb9d5228d
 Corso molto interessante, forse più di quanto appare dalla sua presentazione sul piano
 studi. Ho avuto l'impressione che tanta gente lo scarti a priori pensando che si tratti di un
@@ -277,7 +277,7 @@ La mia opinione è complessivamente positiva, sia per quanto riguarda gli argome
 modo in cui sono stati spiegati, che il taglio generale del corso.
 
 ###SICUREZZA DELLE RETI
-TELEGRAM https://t.me/joinchat/LclXl1jeOj5MgaS0SMtsmQ
+TELEGRAM https://t.me/joinchat/WN46PhUFZ4CxSiB2
 MANIFEST https://www11.ceda.polimi.it/schedaincarico/schedaincarico/controller/scheda_pubblica/SchedaPublic.do?&evn_default=evento&c_classe=712674&polij_device_category=DESKTOP&__pj0=0&__pj1=d3ed0e0e341de91a0c53fbe462fca676
 Il nome del corso è magari leggermente fuorviante, il contenuto è teoria dei numeri e
 protocolli di comunicazione sicura. Il professore è simpatico e spiega bene, il corso


### PR DESCRIPTION
Output di `inviti_rotti.bash` dopo la patch:
```
$ ./inviti_rotti.bash 
Checking 235 URLs...
it/guides/info/corsi3.txt:341: https://t.me/joinchat/LclXl027QDEBUo1m_fSghA
it/guides/testanddev/corsi3.txt:341: https://t.me/joinchat/LclXl027QDEBUo1m_fSghA
```
Si tratta dell'invito per il gruppo di "progetto di ingegneria informatica": su https://polinetwork.github.io/search/it, non riesco a trovarlo; sul [google spreadsheet dove ci sono gli inviti per i gruppi del secondo semestre del terzo anno di ingegneria informatica/telecomunicazioni](https://docs.google.com/spreadsheets/d/1BdL-h65Qpti8fcbgm8Z0b2HpIG6kSLM_oEkvCYK5YX4), l'invito che c'è non funziona (è lo stesso che è nelle pagine).